### PR TITLE
Enable commenting

### DIFF
--- a/lib/expando/version.rb
+++ b/lib/expando/version.rb
@@ -1,3 +1,3 @@
 module Expando
-  VERSION = '0.2.3'
+  VERSION = '1.0.0'
 end

--- a/spec/expando/expander_spec.rb
+++ b/spec/expando/expander_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
 describe Expando::Expander do
-  it 'properly expands tokenized text' do
-    lines = [ '(I|we|they) heard you (love|hate) (cars|boats|bikes)' ]
-    expanded_lines = [
+  let(:lines) { [ '(I|we|they) heard you (love|hate) (cars|boats|bikes)' ] }
+  let(:expanded_lines) {
+    [
       'I heard you love cars',
       'I heard you love boats',
       'I heard you love bikes',
@@ -23,7 +23,22 @@ describe Expando::Expander do
       'they heard you hate boats',
       'they heard you hate bikes',
     ]
+  }
 
+  it 'properly expands the tokenized text' do
     expect( Expando::Expander.expand!( lines ) ).to eq( expanded_lines )
+  end
+
+  context 'when some lines are commented out' do
+    let(:lines) {
+      [
+        '# this is a comment',
+        '(I|we|they) heard you (love|hate) (cars|boats|bikes)'
+      ]
+    }
+
+    it 'properly expands the tokenized text, ignoring the commented lines' do
+      expect( Expando::Expander.expand!( lines ) ).to eq( expanded_lines )
+    end
   end
 end


### PR DESCRIPTION
Lines beginning with `#` will be ignored. This enables commenting within Expando source files.